### PR TITLE
Changes to make the plugin compatible with dokku v3.15

### DIFF
--- a/commands
+++ b/commands
@@ -15,8 +15,8 @@ case "$1" in
         UUID=$(uuidgen)
         git clone "$2" "$UUID"
         cd "$UUID"
-        dokku create "$UUID"
-        tar c . | dokku build "$UUID"
+        dokku apps:create "$UUID"
+        tar c . | dokku build "$UUID" buildstep
         docker tag "dokku/$UUID" "$3"
         docker push "$3"
         dokku delete "$UUID"

--- a/commands
+++ b/commands
@@ -16,7 +16,13 @@ case "$1" in
         git clone "$2" "$UUID"
         cd "$UUID"
         dokku apps:create "$UUID"
-        tar c . | dokku build "$UUID" buildstep
+        DOCKERFILE=$(ls -l | grep Dockerfile | wc -l )
+        if [ $((DOCKERFILE)) -eq 1 ]; then
+            IMAGE_TYPE="dockerfile"
+        else
+            IMAGE_TYPE="herokuish"
+        fi
+        tar c . | dokku build "$UUID" "$IMAGE_TYPE"
         docker tag "dokku/$UUID" "$3"
         docker push "$3"
         dokku delete "$UUID"


### PR DESCRIPTION
Dokku commands have changed, so:
- now to create an app we need to run apps:create
- we need to specify build step has the build method

This should make this registry:push compatible with Dokku v0.3.15
