### PR TITLE
Upgrade to support Dokku 0.7.x

### DIFF
--- a/commands
+++ b/commands
@@ -32,8 +32,7 @@ case "$1" in
     mkdir -p "$DOKKU_ROOT/$APP"
     docker pull "$DOCKER_REGISTRY_IMAGE"
     docker tag "$DOCKER_REGISTRY_IMAGE" "dokku/$APP"
-    dokku release "$APP"
-    dokku deploy "$APP"
+    dokku tags:deploy "$APP"
     ;;
 
   help | registry:help)


### PR DESCRIPTION
`dokku release` is no longer a public command and the `dokku
tags:deploy` functionality can be neatly used for this instead.
